### PR TITLE
Clean up seminar pages

### DIFF
--- a/content/pure/archive/index.md
+++ b/content/pure/archive/index.md
@@ -1,0 +1,12 @@
+---
+title: Pure PGR Seminar Archive
+---
+
+This is an archive for past versions of the pure PGR seminar, they are separated by academic year.
+
+We currently have titles and abstracts going back to February 2022.
+If you have records going back further, please get in touch!
+
+- [2021-22](./seminar-2021-22.html), organised by Paul Leask and Simon May
+- [2022-23](./seminar-2022-23.html), organised by Tathagata Ghosh and Shuang Zheng
+- [2023-24](../seminar.html) (current), organised by Benji Morris, Luca Seemungal, Tathagata Ghosh, and Shuang Zheng 

--- a/content/pure/archive/seminar-2021-22.md
+++ b/content/pure/archive/seminar-2021-22.md
@@ -1,0 +1,36 @@
+---
+title: Pure PGR Seminar
+subtitle: Academic Year 2021-22
+---
+
+Jump to:
+
+- [Spring term](#spring)
+
+Organised by:
+
+- Paul Leask
+- Simon May
+
+## Spring Term{#spring}
+
+### 17 Feb{.talk-date}
+#### [Tathagata Ghosh]{.speaker-name} — [Deformation Theory of Asymptotically Conical Spin(7)-Instantons]{.talk-title} {.speaker-title}
+
+*Abstract*: In this talk we discuss the deformation theory of instantons on asymptotically conical $\mathrm{Spin}(7)$-manifolds where the instanton is asymptotic to a fixed nearly $G_2$-instanton at infinity.
+By relating the deformation complex with Dirac operators and spinors, we apply spinorial methods to identify the space of infinitesimal deformations with the kernel of the twisted Dirac operator on the asymptotically conical $\mathrm{Spin}(7)$-manifold.
+
+### 24 Feb{.talk-date}
+#### [Joel Costa da Rocha]{.speaker-name} — [Parametrizing positroid cells using bicolored tilings]{.talk-title} {.speaker-title}
+
+*Abstract*: We define bicolored tilings as a disk with a collection of smooth curves with a coloring map on the tiles that these curves delimit.
+Postnikov diagrams can be viewed as the image of reduced tilings under the Scott map.
+Using bicolored tilings, we can parametrise positroid cells in the Grassmannian.
+The postroid cell associated to a tiling is invariant under flip equivalence and reduction of tilings.
+
+### 10 Mar{.talk-date}
+#### [Thomas Galvin]{.speaker-name} — [The Penrose Transform]{.talk-title} {.speaker-title}
+
+*Abstract*: We will discuss the Penrose Transform which is an aspect of twistor theory.
+The Penrose Transform relates solutions to PDEs in $\mathbb{R}^n$ to holomorphic objects in an associated complex manifold called the twistor space.
+We will mostly focus on the example of the Laplace equation in $\mathbb{R}^3$ and finish with a generalization developed by Murray (1985) for the case of any homogeneous polynomial differential operators in $\mathbb{R}^n$.

--- a/content/pure/archive/seminar-2021-22.md
+++ b/content/pure/archive/seminar-2021-22.md
@@ -1,6 +1,8 @@
 ---
 title: Pure PGR Seminar
 subtitle: Academic Year 2021-22
+header-includes:
+    <link rel="stylesheet" href="/static/pure-seminar.css" />
 ---
 
 Jump to:

--- a/content/pure/archive/seminar-2022-23.md
+++ b/content/pure/archive/seminar-2022-23.md
@@ -1,6 +1,8 @@
 ---
 title: Pure PGR Seminar
 subtitle: Academic Year 2022-23
+header-includes:
+    <link rel="stylesheet" href="/static/pure-seminar.css" />
 ---
 
 Jump to:

--- a/content/pure/archive/seminar-2022-23.md
+++ b/content/pure/archive/seminar-2022-23.md
@@ -1,0 +1,144 @@
+---
+title: Pure PGR Seminar
+subtitle: Academic Year 2022-23
+---
+
+Jump to:
+
+- [Autumn term](#autumn)
+- [Spring term](#spring)
+
+Organised by:
+
+- Tathagata Ghosh
+- Shuang Zheng
+
+## Autumn Term{#autumn}
+
+### 13 Oct{.talk-date}
+#### [Calliope Ryan-Smith]{.speaker-name} — [Basics of Model Theory]{.talk-title} {.speaker-title}
+
+*Abstract*: You may, at various points in your life, be forced to interact with a model theorist.
+While this is no cause for alarm on its own, the notion that you may then be expected to sit in a room while a model theorist gives a talk can be troubling to some.
+Have no fear, for I will explain the basic machinery of model theory by exhibiting its intuitive roots.
+The ideas of languages, models, and theories build on very reasonable generalisations of structures found all over mathematics, and by looking at models in that generality we are led to powerful tools that have wide-reaching applications.
+
+### 20 Oct{.talk-date}
+#### [Tat Ghosh]{.speaker-name} — [An Introduction to Mathematical Gauge Theory]{.talk-title} {.speaker-title}
+
+*Abstract*: In this talk, I'll explain what mathematical gauge theory is.
+I'll (somewhat informally) discuss the mathematical prerequisites, namely, the notions of smooth manifolds, differential forms, vector and principal bundles, connections, curvature etc.
+Finally, I'll discuss the heart of gauge theory: Yang-Mills equations, Instantons and monopoles using all the mathematical tools discussed during the talk.
+
+
+The objectives of this talk are three-folds.
+First, to explain the main ideas of gauge theory to non-specialists.
+Second, to discuss some particular ideas so that this talk will act as a prelude to many upcoming talks.
+Third, to connect these notions to various other brunches of mathematics to convince the non-geometers that these mathematical objects are important in their fields as well!
+
+### 27 Oct{.talk-date}
+#### [Ibrahim Mohammed]{.speaker-name} — [Model theory of Real closed fields ]{.talk-title} {.speaker-title}
+
+*Abstract*: An ordered field is real closed if any positive element has a square root and all odd degree polynomials have a solution.
+These properties can be translated quite easily into a model theoretic structure so it makes sense so see what properties these structures have.
+
+It turns out that the theory of real closed fields has quantifier elimination, is model complete and o-minimal.
+These properties can be used to give slick proofs of certain classical results concerning semialgebraic sets such the Tarski–Seidenberg theorem (all semialgebraic sets are closed under projection).
+
+The property of model completeness stated earlier means that if something is true in one real closed field, it's true in any real closed field extension.
+We can leverage this to give short proofs of Hilbert's 17th Problem (all semi-definite rational functions can be written as the sum of squares of rational functions) and a real version of the Nullstellensatz.
+All the material from this talk will be based on section 3.3 in the book "Model theory: An Introduction" by David Marker.
+
+### 10 Nov{.talk-date}
+#### [Aris Papadopoulos]{.speaker-name} — [Ramsey Theory: What does it do? Does it do things? Let's find out?]{.talk-title} {.speaker-title}
+
+*Abstract*: The pigeonhole principle is the assertion that if two pigeons were in one hole, then there was one hole that contained two pigeons.
+This observation can be generalised.
+I'll discuss some generalisations.
+
+### 17 Nov{.talk-date}
+#### [Ravil Gabdurakhmanov]{.speaker-name} — [Proofs of a couple of Fermat's theorems by Symmetry]{.talk-title} {.speaker-title}
+
+*Abstract*: We will follow the elegant proof of Fermat's Christmas theorem by Zagier using the method of counting the fixed points of some special involutions.
+Then we will discuss a "geometric" proof of Fermat's little theorem using counting techniques involving group action of a cyclic group on its group algebra.
+
+### 24 Nov{.talk-date}
+#### [Carla Simons]{.speaker-name} — [Cardinal Sequences of Topological Spaces]{.talk-title} {.speaker-title}
+
+*Abstract*: In this talk, I’ll explain how to find the cardinal sequence of a topological space.
+We are especially interested in cardinal sequences of locally compact, scattered, Hausdorff topological spaces (LCS spaces).
+Given a sequence $\theta$ of cardinals, we’d like to find out whether there exists an LCS space which has cardinal sequence $\theta$ (or, failing that, whether the existence of such a space is consistent with the axioms of set theory).
+I will discuss some existing results about this problem, and some open questions.
+
+### 01 Dec{.talk-date}
+#### [Mervyn Tong]{.speaker-name} — [The Odd Goldbach Conjecture and the Hardy-Littlewood Circle Method]{.talk-title} {.speaker-title}
+
+*Abstract*: In this talk, I will outline a proof of (a weak version of) the Odd Goldbach Conjecture, which states that every sufficiently large odd number can be written as the sum of three primes.
+I will explain the Hardy-Littlewood circle method, an important tool in analytic number theory that forms the backbone of the proof.
+Along the way, we will see why a different proof is needed to obtain an effective bound for ‘sufficiently large’, and why the proof cannot be readily adapted to prove the (Even) Goldbach Conjecture, which posits that every even number can be written as the sum of two primes.
+
+### 15 Dec{.talk-date}
+#### [Gautam Chaudhuri]{.speaker-name} — [An Introduction to Vortices]{.talk-title} {.speaker-title}
+
+*Abstract*: Vortices are topological solitons on Riemann surfaces initially studied as models of supercurrents in a strong magnetic field.
+More recently, generalisations of vortices have been used to define novel invariants on symplectic manifolds and have deep ties to the theory of vector bundles over complex algebraic curves.
+In this talk we will look at various examples of vortices in the Abelian Higgs model, building up from global vortices on the complex plane to gauged vortices on a compact Riemann surface.
+Time permitting we will consider slight generalisations such as non-Abelian and symplectic vortices.
+
+## Spring Term{#spring}
+
+### 16 Feb{.talk-date}
+#### [Benjamin Morris]{.speaker-name} — [Towards a factorised solution of the Yang-Baxter equation with $\mathrm{U}_q(\mathfrak{sl}_n)$ symmetry]{.talk-title} {.speaker-title}
+
+*Abstract*: This talk will begin with an introduction to almost cocommutative Hopf algebras, as a fertile soil on which to study Yang-Baxter (YB) type equations that possess inherent symmetry.
+We then introduce and apply the so called "RLL-method" with the aim of obtaining solutions of the YBE acting in the tensor product of two "generic" lowest weight representations of the symmetry algebras $A = \mathrm{U}(\mathfrak{sl}_n), \mathrm{U}_q(\mathfrak{sl}_n)$.
+
+The "generic" class of representations we are aiming for are differential  
+($q$-difference) representations of $A$ on a function space in $\frac{n(n-1)}{2}$ variables.
+The defining relations for a YB R-matrix can be interpreted as a permutation condition allowing for its factorisation into elementary transposition operators.
+
+### 23 Feb{.talk-date}
+#### [Oscar Brauer]{.speaker-name} — [Moduli Spaces and the Double ramification hierarchy]{.talk-title} {.speaker-title}
+
+*Abstract*: The double ramification (DR) hierarchy provides a new way to approach problems in the geometry and topology of moduli spaces, as well as connections with mathematical physics, such as the Eynard-Oratin topological recursion and integrable systems.
+The DR hierarchy is related to the study of the DR cycle, which is a cohomology class associated to a pair of integers called the ramification profile.
+The hierarchy can be thought of as an infinite sequence of equations which relate certain classes on the moduli space of algebraic curves, and it encodes information about the geometry of the moduli space.
+The double ramification hierarchy has also been used to study Gromov-Witten invariants and to understand mirror symmetry.
+
+In this talk, we will introduce moduli spaces and cohomological field theories (CohFT) to motivate the key concepts behind the double ramification cycle (DR cycle) and the DR hierarchy.
+We will review some basic  examples of moduli spaces and cohomological field theories.
+To help us understand the DR classes and their properties, we will compute the first classes for the trivial CohFT, which leads to the KdV hierarchy.
+This will give us a glimpse of the intricate connections between the DR hierarchy, CohFTs, and integrable systems.
+
+### 02 Mar{.talk-date}
+#### [Jack Romo]{.speaker-name} — [Diffeology: A Theory of Smoothness with Good Manners]{.talk-title} {.speaker-title}
+
+*Abstract*: The idea of a space, map or other construction being ‘smooth’ rears its head throughout a variety of subjects in mathematics.
+Smooth manifolds are a fundamental construction throughout mathematical physics, differential geometry and geometric topology.
+Unfortunately, the category of smooth manifolds is somewhat poorly behaved; limits and colimits are rare at best, while internal hom’s are entirely unheard of.
+
+A solution to this conundrum is the theory of diffeological spaces, a structure whose category has all (co)limits and is Cartesian closed while containing smooth manifolds with smooth maps as a full subcategory.
+On closer inspection, this category turns out to host a veritable zoo of smooth structures, including among its members smooth manifolds with boundary and corners, orbifolds, infinite-dimensional manifolds, Hilbert spaces, diffeomorphism groups and much more.
+The constructions available on these objects are similarly diverse, ranging from differential-geometric notions like differential forms and de Rham cohomology to algebra-topoolgical ones like smooth homotopy groups.
+The power to apply all these constructions to all the above examples in the same category is rather startling.
+
+In this talk, I will introduce the basic ideas behind diffeological spaces, giving a taste of the different examples and constructions possible in this powerful category.
+
+### 16 Mar{.talk-date}
+#### [Shuangshuang Shu]{.speaker-name} — [Self-reference]{.talk-title} {.speaker-title}
+
+*Abstract*: It'll be something about provability and truth of statements, but this abstract is false.
+
+### 23 Mar{.talk-date}
+#### [Pietro Freni]{.speaker-name} — [How do you solve a system of polynomial equations?]{.talk-title} {.speaker-title}
+
+*Abstract*: It will be a basic talk about some computational aspects of elimination theory, namely Gröbner bases and Buchberger's algorithm.
+
+The main goal of the talk will be to provide a very gentle (but hopefully precise) introduction to the two aforementioned objects, although -time permitting- I may hint at applications of this theory to effectively computing some homological invariants of finitely generated modules over a ring of multivariate polynomials (over a field).
+
+### 30 Mar{.talk-date}
+#### [Alexandra Pestana Policarpo De Gouveia]{.speaker-name} — [The C in ZFC]{.talk-title} {.speaker-title}
+
+*Abstract*: Most mathematicians first formally encounter the Axiom of Choice in the form of Zorn's Lemma, even though they have been using some form of choice without second thought.
+We will briefly look at the controversial history of this axiom and how the matter has been "settled" by logicians in a way that makes its acceptance a philosophical matter.
+Then we will look at common implicit uses of choice, as well as some counterintuitive consequences of it and the chaos that is unleashed in its absence.

--- a/content/pure/index.md
+++ b/content/pure/index.md
@@ -3,3 +3,8 @@ title: Pure Mathematics
 ---
 
 Your Pure PGR representative is Hope Duncan.
+
+Links:
+
+- [Pure PGR Seminar](./seminar.html)
+- [Pure PGR Seminar Archive](./archive/)

--- a/content/pure/seminar.md
+++ b/content/pure/seminar.md
@@ -101,10 +101,9 @@ In particular, we will discuss a theorem, originally due to S. Lie and rediscove
 
 
 ### 29 Apr{.talk-date}
+#### [Hope Duncan]{.speaker-name} — [An introduction to large cardinals.]{.talk-title} {.speaker-title}
 
 [**NOTE THE CHANGE OF ROOM: ROGER STEVENS LT 09**]{style="color: red"}
-
-#### [Hope Duncan]{.speaker-name} — [An introduction to large cardinals.]{.talk-title} {.speaker-title}
 
 *Abstract:* Large cardinals are an important aspect of modern set theory, allowing us to expand our understanding of infinite cardinals, and providing a rich hierarchy with applications in many areas of mathematics. We will provide the necessary background to understand what large cardinals are, look at the assumptions needed to produce a wordly cardinal, and show that this is independent from ZFC. We will then look at the applications of Large Cardinals within set theory and beyond.
 

--- a/content/pure/seminar.md
+++ b/content/pure/seminar.md
@@ -1,6 +1,8 @@
 ---
 title: Pure PGR Seminar
 subtitle: Academic Year 2023-24
+header-includes:
+    <link rel="stylesheet" href="/static/pure-seminar.css" />
 ---
 
 [CLICK HERE FOR THE NEXT TALK](#next)

--- a/content/pure/seminar.md
+++ b/content/pure/seminar.md
@@ -19,6 +19,8 @@ To give a talk, or if you have a preference for post-seminar treats, contact one
 * Benji Morris, mmbajm at leeds.ac.uk
 * Shuang Zheng (Mia),
 
+Previous incarnations of this seminar can be found [here](./archive).
+
 ## Autumn Term{#autumn}
 
 ## Spring Term{#spring}

--- a/content/pure/seminar.md
+++ b/content/pure/seminar.md
@@ -1,8 +1,14 @@
 ---
 title: Pure PGR Seminar
+subtitle: Academic Year 2023-24
 ---
 
 [CLICK HERE FOR THE NEXT TALK](#next)
+
+Jump to:
+
+- [Autumn term](#autumn)
+- [Spring term](#spring)
 
 Talks are on **Mondays** at **4pm** in the **MALL**, *unless otherwise stated*.
 By custom, there is an offering of coffee and cakes after!
@@ -12,6 +18,10 @@ To give a talk, or if you have a preference for post-seminar treats, contact one
 * Luca Seemungal, mmlse@leeds.ac.uk
 * Benji Morris, mmbajm at leeds.ac.uk
 * Shuang Zheng (Mia),
+
+## Autumn Term{#autumn}
+
+## Spring Term{#spring}
 
 ### 08 Apr{.talk-date}
 #### [Gautam Chaudhuri]{.speaker-name} — [Vortices and the Geodesic Approximation]{.talk-title} {.speaker-title}

--- a/content/pure/seminar.md
+++ b/content/pure/seminar.md
@@ -23,7 +23,58 @@ Previous incarnations of this seminar can be found [here](./archive).
 
 ## Autumn Term{#autumn}
 
+### 13 Nov{.talk-date}
+#### [Julia Hörmayer]{.speaker-name} — [Postnikov Diagrams: A Cluster Algebra]{.talk-title} {.speaker-title}
+
+*Abstract*: Introduced as recently as 2002 by Fomin and Zelevinsky, cluster algebras are all the craze at the moment.
+Surely but not exactly slowly, we can all watch them take over the mathematical world.
+Long gone are the times in which their radius of influence was restricted to algebraists alone.
+Combinatorialists, algebraic geometers and even physicists have taken a liking to the iteratively defined fellows, to name only a few.
+If you have somehow been missing out on the fun so far, fear not and instead embark with me on a journey through their history, leading up to the use of Postnikov’s alternating strand diagrams to combinatorially describe the cluster structure of the Grassmannian.
+
+### 04 Dec{.talk-date}
+#### [Manuel Concha _(Visiting PGR from Universidad de Talca)_]{.speaker-name} — [Macdonald polynomials and Pieri Rules]{.talk-title} {.speaker-title}
+
+*Abstract*: Symmetric functions play a fundamental role in various areas of mathematics, such as combinatorics, representation theory, and physics.
+Three decades ago, Macdonald polynomials were introduced, which generalize many important basis in the theory and have combinatorial properties.
+
+Recently, a generalization of Macdonald polynomials in superspace has been carried out, where these new polynomials depend on anticommutant variables.
+It has been observed that these polynomials also retain combinatorial properties that extend naturally to the Macdonald polynomials.
+
+In this talk, basic notions of symmetric functions will be presented.
+We will talk about Macdonald polynomials and their combinatorial properties, to end by talking about the case in superspace.
+
 ## Spring Term{#spring}
+
+### 19 Feb{.talk-date}
+#### [Luca Seemungal]{.speaker-name} — [A Talk Wherein I Tell You As Much as I Can About the Isoperimetric Problem in a Fixed Amount of Time]{.talk-title} {.speaker-title}
+
+*Abstract*: We are all familiar with the classical variational problem of cramming the most amount of material in the shortest amount of time — by the end of this talk, you will be intimately familiar with this problem.
+The isoperimetric problem is a geometric interpretation of this ancient noumenon, which asks you to find the shape that has the smallest perimeter for fixed area.
+In this talk I use the isoperimetric problem as a motivation to take you on a whistle-stop tour of as much geometric analysis as I can.
+Along the way, we will sketch proofs no fewer than THREE WHOLE THEOREMS (time permitting): the isoperimetric inequality for curves, the Sobolev inequality, and the dizzyingly amazing fact of their equivalence.
+I will mention one of my own results, though briefly: blink, and you'll miss it!
+
+### 26 Feb{.talk-date}
+#### [Calliope Ryan-Smith]{.speaker-name} — [Forcing in Set Theory]{.talk-title} {.speaker-title}
+
+*Abstract*: Cohen's method of forcing was a groundbreaking advance in set theory that allowed one to extend models of ZF(C) with relative ease.
+The first application showed that the continuum hypothesis may be falsified in ZFC which, alongside Gödel's constructible universe twenty years prior, answered the millenium question.
+We shall have a brief look into these techniques to see how it works.
+
+### 04 Mar{.talk-date}
+#### [Jacob Smith]{.speaker-name} — [The Regular Case of Optimal Stopping]{.talk-title} {.speaker-title}
+
+*Abstract*: The study of optimal stopping problems has a long history, but the seminal work by El Karoui expanded the reach of the analysis.
+In this talk, I will present the first generalisation of problems of optimal stopping and the solution methods.
+
+### 25 Mar{.talk-date}
+#### [Benji Morris]{.speaker-name} — [Lattice Statistical Mechanics is Algebra]{.talk-title} {.speaker-title}
+
+*Abstract*: In this seminar I will introduce lattice statistical mechanics insofar as it is a source of concrete mathematical objects worth computing.
+The main protagonist in this story is the transfer matrix which provides a computational formalism amenable to a mathematical deconstruction, whereby a deep connection is revealed with objects of interest in the modern field of algebra.
+Topics may include transfer matrix algebras (including the celebrated Temperley-Lieb algebra), star-triangle identities and commuting transfer matrices, and Baxter’s famous TQ-method.
+
 
 ### 08 Apr{.talk-date}
 #### [Gautam Chaudhuri]{.speaker-name} — [Vortices and the Geodesic Approximation]{.talk-title} {.speaker-title}

--- a/static/pure-seminar.css
+++ b/static/pure-seminar.css
@@ -1,0 +1,19 @@
+body {
+    text-align: justify;
+}
+
+h3.talk-date, h4.speaker-title {
+    font-size: 1.2em;
+}
+
+h3.talk-date {
+    margin-bottom: 0;
+}
+
+h4.speaker-title {
+    margin-top: 0;
+    margin-bottom: 0.25em;
+    font-weight: normal;
+    font-style: italic;
+    color: #3a3a3a;
+}


### PR DESCRIPTION
Added titles and abstracts for past incarnations of the pure PGR seminar, including those for the 2023-24 session prior to 2024-04-08 (when the current site was created).

Also made some changes to the CSS of the pure seminar pages.